### PR TITLE
The platform and aux configurations can now be created elsewhere.

### DIFF
--- a/src/main/groovy/org/standardout/gradle/plugin/platform/PlatformPlugin.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/PlatformPlugin.groovy
@@ -80,8 +80,8 @@ public class PlatformPlugin implements Plugin<Project> {
 		downloadsDir = new File(project.buildDir, 'eclipse-downloads')
 		
 		// create configuration
-		project.configurations.create CONF_PLATFORM
-		project.configurations.create CONF_AUX
+		project.configurations.maybeCreate CONF_PLATFORM
+		project.configurations.maybeCreate CONF_AUX
 		
 		project.afterEvaluate {
 			// feature version default


### PR DESCRIPTION
This allows bnd-platform to be applied lazily to a project.

Consider a multi-project build like this:

```
build.gradle // root project file
pluginA/
    build.gradle
pluginB ... F
targetplatform
    build.gradle  // apply `bnd-platform`
```

Where the root project file looks like this:

```groovy
project(':targetplatform') {
    // bnd-platform will look for this configuration
    configurations {
        platform
    }
}

configure(subprojects.findAll({ it.name.startsWith('plugin'))) {
    project(':targetplatform').dependencies.add('platform', it)
}
```

This way, the user can run `gradlew :pluginA:build` without ever incurring the runtime cost of initializing bnd-platform.  Without this commit, the above project would fail like this:

```
> Failed to apply plugin [id 'org.standardout.bnd-platform']
   > Cannot add a configuration with name 'platform' as a configuration with that name already exists.
```
