### PR TITLE
#21: make downloadsDir configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,7 @@ Via the platform extension there are several settings you can provide:
 * **updateSiteZipFile** - the target file for the zipped p2 repository (default: `new File(buildDir, 'updatesite.zip')`)
 * **eclipseHome** - File object pointing to the directory of a local Eclipse installation to be used for generating the p2 repository (default: `null`)
 * **eclipseMirror** - Eclipse download URLs to be used when no local installation is provided via *eclipseHome*, the URLs are identified per osgiOS (win32, linux, macosx), osgiWS (win32, gtk, cocoa) and arch (x86, x86_64), e.g. `eclipseMirror.win32.win32.x86_64 = ...` (defaults to official Eclipse mirrors with Eclipse Indigo)
+* **downloadsDir** -  the directory to store the downloaded Eclipse installation on local, this works if *eclipseHome* is not specified. (default: `new File(buildDir, 'eclipse-downloads')`)
 * **featureId** - the identifier of the feature including the platform bundles that will be available in the created update site (default: **'platform.feature'**)
 * **featureName** - the name of the feature including the platform bundles that will be available in the created update site (default: **'Generated platform feature'**)
 * **featureVersion** - the version number for the feature including the platform bundles that will be available in the created update site (defaults to the project version)

--- a/src/main/groovy/org/standardout/gradle/plugin/platform/PlatformPlugin.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/PlatformPlugin.groovy
@@ -62,8 +62,7 @@ public class PlatformPlugin implements Plugin<Project> {
 	private File bundlesDir
 	private File categoryFile
 	private File featuresDir
-	private File downloadsDir
-	
+
 	@Override
 	public void apply(Project project) {
 		this.project = project
@@ -81,8 +80,7 @@ public class PlatformPlugin implements Plugin<Project> {
 		bundlesDir = new File(project.buildDir, 'plugins')
 		categoryFile = new File(project.buildDir, 'category.xml')
 		featuresDir = new File(project.buildDir, 'features')
-		downloadsDir = new File(project.buildDir, 'eclipse-downloads')
-		
+
 		// create configuration
 		project.configurations.maybeCreate CONF_PLATFORM
 		project.configurations.maybeCreate CONF_AUX
@@ -100,6 +98,13 @@ public class PlatformPlugin implements Plugin<Project> {
 			}
 			if (project.platform.featureVersion == null) {
 				project.platform.featureVersion = '1.0.0'
+			}
+
+			if (project.platform.downloadsDir == null) {
+				project.platform.downloadsDir = new File(project.buildDir, 'eclipse-downloads')
+			}
+			if (!project.platform.downloadsDir.exists()) {
+				project.platform.downloadsDir.mkdirs()
 			}
 		}
 
@@ -208,7 +213,7 @@ public class PlatformPlugin implements Plugin<Project> {
 			def eclipseHome = System.properties['ECLIPSE_HOME']
 			
 			if (!eclipseHome) {
-				File downloadedEclipse = new File(downloadsDir, 'eclipse')
+				File downloadedEclipse = new File(project.platform.downloadsDir, 'eclipse')
 				if (downloadedEclipse.exists()) {
 					// downloaded Eclipse already exists
 					eclipseHome = downloadedEclipse
@@ -222,8 +227,8 @@ public class PlatformPlugin implements Plugin<Project> {
 						// Download artifact
 						String artifactDownloadUrl = artifacts[project.ext.osgiOS][project.ext.osgiWS][project.ext.osgiArch]
 						def filename = artifactDownloadUrl.substring(artifactDownloadUrl.lastIndexOf('/') + 1)
-						def artifactZipPath = new File(downloadsDir, filename)
-						def artifactZipPathPart = new File(downloadsDir, filename + '.part')
+						def artifactZipPath = new File(project.platform.downloadsDir, filename)
+						def artifactZipPathPart = new File(project.platform.downloadsDir, filename + '.part')
 						if (!artifactZipPath.exists()) {
 							project.download {
 								src artifactDownloadUrl
@@ -235,7 +240,7 @@ public class PlatformPlugin implements Plugin<Project> {
 				
 						// Unzip artifact
 						println('Copying ' + name + ' ...')
-						def artifactInstallPath = downloadsDir
+						def artifactInstallPath = project.platform.downloadsDir
 						if (artifactZipPath.name.endsWith('.zip')) {
 							project.ant.unzip(src: artifactZipPath, dest: artifactInstallPath)
 						} else {

--- a/src/main/groovy/org/standardout/gradle/plugin/platform/PlatformPluginExtension.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/PlatformPluginExtension.groovy
@@ -299,7 +299,14 @@ class PlatformPluginExtension {
 	 * well it is tried to download Eclipse based on the URLs defined in {@link #eclipseMirror}
 	 */
 	File eclipseHome
-	
+
+	/**
+	 * The direct to store the downloaded Eclipse installation on local, 
+	 * this works if <code>eclipseHome</code> is not specified.
+	 * Default to <code>project.buildDir</code>.
+	 */
+	File downloadsDir
+
 	/**
 	 * Nested map that is checked for Eclipse download URLs, keys are
 	 * osgiOS (win32, linux, macosx), osgiWS (win32, gtk, cocoa) and

--- a/src/main/groovy/org/standardout/gradle/plugin/platform/PlatformPluginExtension.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/PlatformPluginExtension.groovy
@@ -301,9 +301,9 @@ class PlatformPluginExtension {
 	File eclipseHome
 
 	/**
-	 * The direct to store the downloaded Eclipse installation on local, 
+	 * The directory to store the downloaded Eclipse installation on local, 
 	 * this works if <code>eclipseHome</code> is not specified.
-	 * Default to <code>project.buildDir</code>.
+	 * Default to <code>project.buildDir/eclipse-downloads</code>.
 	 */
 	File downloadsDir
 


### PR DESCRIPTION
for #21

sample usage:
```groovy
platform {
       downloadsDir = new File(System.properties['user.home'], '.bnd-eclipse')
}
```