### PR TITLE
Manage feature depenencies better

### DIFF
--- a/src/main/groovy/org/standardout/gradle/plugin/platform/internal/DefaultFeature.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/internal/DefaultFeature.groovy
@@ -49,7 +49,7 @@ class DefaultFeature implements Feature {
 	}
 	
 	@Override
-	public Iterable<BundleArtifact> getBundles() {
+	public Iterable<BundleArtifact> getIncludedBundles() {
 		bundles == null ? [] : bundles
 	}
 
@@ -58,4 +58,13 @@ class DefaultFeature implements Feature {
 		includedFeatures == null ? [] : includedFeatures
 	}
 
+	@Override
+	Iterable<BundleArtifact> getRequiredBundles() {
+		[]
+	}
+
+	@Override
+	Iterable<Feature> getRequiredFeatures() {
+		[]
+	}
 }

--- a/src/main/groovy/org/standardout/gradle/plugin/platform/internal/Feature.java
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/internal/Feature.java
@@ -19,7 +19,7 @@ package org.standardout.gradle.plugin.platform.internal;
 /**
  * Represents an Eclipse Update Site Feature.
  * 
- * The version, bundles and includedFeatures properties may only be accessed
+ * The version, bundles and features properties may only be accessed
  * after the feature configuration is complete.
  */
 public interface Feature {
@@ -32,8 +32,12 @@ public interface Feature {
 	
 	public String getProviderName();
 	
-	public Iterable<BundleArtifact> getBundles();
+	public Iterable<BundleArtifact> getIncludedBundles();
 	
-	public Iterable<Feature> getIncludedFeatures();
+	public Iterable<Feature> getIncludedFeatures();	
+	
+	public Iterable<BundleArtifact> getRequiredBundles();
+	
+	public Iterable<Feature> getRequiredFeatures();
 	
 }

--- a/src/main/groovy/org/standardout/gradle/plugin/platform/internal/config/ArtifactFeature.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/internal/config/ArtifactFeature.groovy
@@ -143,6 +143,9 @@ class ArtifactFeature implements Feature {
 			artifacts.removeAll(transitiveArtifacts(includedBundles.toList()))
 		}
 
+		// Remove self included bundles
+		artifacts.removeAll(getIncludedBundles())
+
 		artifacts
 	}
 

--- a/src/main/groovy/org/standardout/gradle/plugin/platform/internal/config/ArtifactFeature.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/internal/config/ArtifactFeature.groovy
@@ -135,7 +135,15 @@ class ArtifactFeature implements Feature {
 
 	@Override
 	Iterable<BundleArtifact> getRequiredBundles() {
-		transitiveArtifacts(getIncludedBundles())
+		def artifacts = transitiveArtifacts(getIncludedBundles()).toSet()
+
+		// Remove artifacts that are already in required features
+		for (Feature feature : getRequiredFeatures()) {
+			def includedBundles = feature.getIncludedBundles()
+			artifacts.removeAll(transitiveArtifacts(includedBundles.toList()))
+		}
+
+		artifacts
 	}
 
 	private Iterable<BundleArtifact> transitiveArtifacts(Collection<BundleArtifact> artifacts) {

--- a/src/main/groovy/org/standardout/gradle/plugin/platform/internal/config/ArtifactFeature.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/internal/config/ArtifactFeature.groovy
@@ -16,8 +16,6 @@
 
 package org.standardout.gradle.plugin.platform.internal.config
 
-import java.util.Set;
-
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedDependency;
@@ -25,7 +23,6 @@ import org.standardout.gradle.plugin.platform.internal.ArtifactsMatch;
 import org.standardout.gradle.plugin.platform.internal.BundleArtifact;
 import org.standardout.gradle.plugin.platform.internal.DependencyArtifact;
 import org.standardout.gradle.plugin.platform.internal.Feature
-import org.standardout.gradle.plugin.platform.internal.ResolvedBundleArtifact;
 import org.standardout.gradle.plugin.platform.internal.util.VersionUtil;
 
 
@@ -51,7 +48,12 @@ class ArtifactFeature implements Feature {
 	/**
 	 * List of included features IDs
 	 */
-	final List<String> configFeatures = []
+	final List<String> configIncludedFeatures = []	
+	
+	/**
+	 * List of required features
+	 */
+	final List<String> configRequiredFeatures = []
 	
 	private String finalVersion
 	
@@ -116,7 +118,7 @@ class ArtifactFeature implements Feature {
 		finalVersion
 	}
 		
-	Iterable<BundleArtifact> getBundles() {
+	Collection<BundleArtifact> getIncludedBundles() {
 		/*
 		 * Attention: a call to this method can only yield a sensible
 		 * result after the artifacts map has been populated by the
@@ -124,16 +126,18 @@ class ArtifactFeature implements Feature {
 		 */
 		
 		// collect all artifacts that match the respective condition
-		def artifacts = project.platform.artifacts.values().findAll { BundleArtifact artifact ->
+		project.platform.artifacts.values().findAll { BundleArtifact artifact ->
 			configArtifacts.any { ArtifactsMatch match ->
 				match.acceptArtifact(artifact)
 			}
 		}
-		
-		// collect transitive dependencies
-		transitiveArtifacts(artifacts)
 	}
-	
+
+	@Override
+	Iterable<BundleArtifact> getRequiredBundles() {
+		transitiveArtifacts(getIncludedBundles())
+	}
+
 	private Iterable<BundleArtifact> transitiveArtifacts(Collection<BundleArtifact> artifacts) {
 		Map<String, BundleArtifact> allArtifacts = [:]
 		
@@ -178,12 +182,19 @@ class ArtifactFeature implements Feature {
 	
 	Iterable<Feature> getIncludedFeatures() {
 		// resolve feature IDs
-		configFeatures.collect {
+		configIncludedFeatures.collect {
 			project.platform.features[it]
 		}.findAll()
 	}
-	
-	/**
+
+	@Override
+	Iterable<Feature> getRequiredFeatures() {
+		// resolve feature IDs
+		configRequiredFeatures.collect {
+			project.platform.features[it]
+		}.findAll()	
+	}
+/**
 	 * Delegate for the configuration closure to intercept calls
 	 * for the feature configuration.
 	 */
@@ -220,7 +231,7 @@ class ArtifactFeature implements Feature {
 				feature.configArtifacts << result
 			}
 			if (result instanceof Feature) {
-				feature.configFeatures << feature.id
+				feature.configIncludedFeatures << feature.id
 			}
 			
 			result
@@ -230,7 +241,10 @@ class ArtifactFeature implements Feature {
 		def getProperty(String name) {
 			if (name == 'includes') {
 				// expose feature list to allow adding feature IDs manually
-				feature.configFeatures
+				feature.configIncludedFeatures
+			}
+			else if (name == 'requires') {
+				feature.configRequiredFeatures
 			}
 			else {
 				orgDelegate."$name"

--- a/src/main/groovy/org/standardout/gradle/plugin/platform/internal/config/SourceFeature.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/internal/config/SourceFeature.groovy
@@ -18,8 +18,7 @@ package org.standardout.gradle.plugin.platform.internal.config
 
 import org.gradle.api.Project;
 import org.standardout.gradle.plugin.platform.internal.BundleArtifact
-import org.standardout.gradle.plugin.platform.internal.Feature;
-import org.standardout.gradle.plugin.platform.internal.util.VersionUtil;
+import org.standardout.gradle.plugin.platform.internal.Feature
 
 class SourceFeature implements Feature {
 	
@@ -46,9 +45,9 @@ class SourceFeature implements Feature {
 	}
 	
 	@Override
-	public Iterable<BundleArtifact> getBundles() {
+	public Iterable<BundleArtifact> getIncludedBundles() {
 		// source bundles
-		feature.bundles.collect { BundleArtifact ba ->
+		feature.includedBundles.collect { BundleArtifact ba ->
 			def bundle = ba.isSource() ? ba : ba.sourceBundle
 			// only accept bundle if it still exists in the artifact map
 			// if it has been removed from there, it was an empty source bundle
@@ -64,4 +63,14 @@ class SourceFeature implements Feature {
 		}.findAll()
 	}
 
+	public Iterable<BundleArtifact> getRequiredBundles(){
+		[]
+	}
+
+	public Iterable<Feature> getRequiredFeatures(){
+		[]
+	}
+
+	
+	
 }

--- a/src/main/groovy/org/standardout/gradle/plugin/platform/internal/util/FeatureUtil.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/internal/util/FeatureUtil.groovy
@@ -56,7 +56,7 @@ class FeatureUtil {
 			}
 		
 			// included bundles
-			for (BundleArtifact artifact : feature.bundles.sort(true, { it.symbolicName })) {
+			for (BundleArtifact artifact : feature.includedBundles.sort(true, { it.symbolicName })) {
 				// define each plug-in
 				plugin(
 					id: artifact.symbolicName,
@@ -64,6 +64,19 @@ class FeatureUtil {
 					'install-size': 0,
 					version: artifact.modifiedVersion,
 					unpack: false)
+			}
+			
+			// required features and bundles
+			requires{
+				for (Feature required : feature.requiredFeatures.sort(true, { it.id })) {
+					if(required.version)
+						'import'(feature: required.id, version: required.version)
+					else
+						'import'(feature: required.id)
+				}
+				for (BundleArtifact artifact : feature.requiredBundles.sort(true, { it.symbolicName })) {
+					'import'(plugin: artifact.symbolicName, version: artifact.modifiedVersion)
+				}
 			}
 		}
 	}

--- a/src/main/groovy/org/standardout/gradle/plugin/platform/internal/util/VersionUtil.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/internal/util/VersionUtil.groovy
@@ -190,7 +190,7 @@ class VersionUtil {
 		def addQualifier
 		
 		// collect bundle IDs and versions
-		def bundles = feature.bundles.collect { BundleArtifact bundle ->
+		def bundles = feature.includedBundles.collect { BundleArtifact bundle ->
 			"${bundle.symbolicName}:${bundle.modifiedVersion}"
 		}.sort()
 		// collect feature IDs and versions


### PR DESCRIPTION
This is the code for a local fork that I created to fix #26.

It changes transitive feature dependencies from direct includes to "requires". It also lets you require other features directly, which will cause bundle dependencies to be ignored if they're provided by these features.

This is just for discussion, I don't expect this to be merged neccesarily.