### PR TITLE
Prevent duplication of SNAPSHOT source bundles

### DIFF
--- a/src/main/groovy/org/standardout/gradle/plugin/platform/internal/BundlesAction.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/internal/BundlesAction.groovy
@@ -100,6 +100,12 @@ class BundlesAction implements Action<Task> {
 						}.find {
 							it.exists()
 						}
+						if (sourceJar) {
+							FileBundleArtifact source = new FileBundleArtifact(artifact, sourceJar)
+							
+							// register artifact so it is included in the platform feature
+							project.platform.artifacts[source.id] = source
+						}
 					}
 				}
 				

--- a/src/main/groovy/org/standardout/gradle/plugin/platform/internal/BundlesAction.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/internal/BundlesAction.groovy
@@ -100,12 +100,6 @@ class BundlesAction implements Action<Task> {
 						}.find {
 							it.exists()
 						}
-						if (sourceJar) {
-							FileBundleArtifact source = new FileBundleArtifact(artifact, sourceJar)
-							
-							// register artifact so it is included in the platform feature
-							project.platform.artifacts[source.id] = source
-						}
 					}
 				}
 				

--- a/src/main/groovy/org/standardout/gradle/plugin/platform/internal/FileBundleArtifact.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/internal/FileBundleArtifact.groovy
@@ -134,13 +134,13 @@ class FileBundleArtifact implements BundleArtifact {
 	 */
 	FileBundleArtifact(BundleArtifact bundle, File sourceBundleFile) {
 		this.file = sourceBundleFile
-		this.id = sourceBundleFile as String
+		this.id = bundle.id + ':sources'
 		this.source = true
 		this.wrap = false // wrapping is done implicitly
 		
 		bndConfig = null
 		
-		version = modifiedVersion = bundle.version
+		version = modifiedVersion = VersionUtil.toOsgiVersion(bundle.version).toString()
 		
 		symbolicName = bundle.symbolicName + '.source'
 		bundleName = bundle.bundleName + ' Sources'

--- a/src/main/groovy/org/standardout/gradle/plugin/platform/internal/FileBundleArtifact.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/internal/FileBundleArtifact.groovy
@@ -140,7 +140,7 @@ class FileBundleArtifact implements BundleArtifact {
 		
 		bndConfig = null
 		
-		version = modifiedVersion = VersionUtil.toOsgiVersion(bundle.version).toString()
+		version = modifiedVersion = bundle.modifiedVersion
 		
 		symbolicName = bundle.symbolicName + '.source'
 		bundleName = bundle.bundleName + ' Sources'


### PR DESCRIPTION
This fixes the duplication of source jars with SNAPSHOT versions
reported in stempler/bnd-platform#14.

The duplicate had a non OSGi-fied version (e.g. 1.0.0-SNAPSHOT)
which lead to errors in the update site creation.