### PR TITLE
Avoid downloading the whole eclipse indigo sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,36 @@ platform {
 }
 ```
 
+### Optional Dependencies
+
+Many third party libraries have optional dependencies being specified by using `<optional>true</optional>` in a pom.xml file.
+
+For example the [Retrofit](https://mvnrepository.com/artifact/com.squareup.retrofit2/retrofit/2.4.0 "Retrofit 2.4.0 on Maven Central") library has android as optional dependency:
+
+```xml
+<dependency>
+  <groupId>com.google.android</groupId>
+  <artifactId>android</artifactId>
+  <optional>true</optional>
+</dependency>
+```
+Since it is unlikely to happen that you want an android dependency in your OSGi application it can be marked as optional:
+
+```groovy
+plugin('com.squareup.retrofit2:retrofit:2.4.0'){
+	bnd {
+		optionalImport 'android.os'
+		optionalImport 'android.net'
+    	}
+}
+```
+Unfortunately the information about the `<optional>true</optional>` instruction is lost during a Gradle build because Gradle's dependency management does not support it yet. (FYI https://docs.gradle.org/4.6/release-notes.html#support-for-optional-dependencies-in-pom-consumption)
+So the bnd-platform plug-in cannot add the optionalImport instructions automatically, yet.
+
+For the [Retrofit](https://mvnrepository.com/artifact/com.squareup.retrofit2/retrofit/2.4.0 "Retrofit 2.4.0 on Maven Central") library it is fairly easy to write the optionalImport instructions like above, but there are other libraries, which have plenty of these `<optional>true</optional>` instruction.
+
+In order to generate the list of potential optional imports a _potentialOptionalImports_ task has been created. This task  creates a _potentialOptionalImports.txt_ file, which lists potential optional imports of each and every bundle, which is created during a build.
+
 ### Sharing configurations
 
 Even though setting up an extensive platform of OSGi bundles can be done quite fast using *bnd-platform*, in many cases additional configuration is necessary. It comes naturally that it should be possible to reuse and share those configurations.

--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ Via the platform extension there are several settings you can provide:
 * **updateSiteDir** - the directory the generated p2 repository is written to (default: `new File(buildDir, 'updatesite')`)
 * **updateSiteZipFile** - the target file for the zipped p2 repository (default: `new File(buildDir, 'updatesite.zip')`)
 * **eclipseHome** - File object pointing to the directory of a local Eclipse installation to be used for generating the p2 repository (default: `null`)
-* **eclipseMirror** - Eclipse download URLs to be used when no local installation is provided via *eclipseHome*, the URLs are identified per osgiOS (win32, linux, macosx), osgiWS (win32, gtk, cocoa) and arch (x86, x86_64), e.g. `eclipseMirror.win32.win32.x86_64 = ...` (defaults to official Eclipse mirrors with Eclipse Indigo)
+* **eclipseMirror** - Eclipse download URLs to be used when no local installation is provided via *eclipseHome*. Uses https://dl.bintray.com/simon-scholz/eclipse-apps/eclipse-p2-minimal.tar.gz by default.
 * **downloadsDir** -  the directory to store the downloaded Eclipse installation on local, this works if *eclipseHome* is not specified. (default: `new File(buildDir, 'eclipse-downloads')`)
 * **featureId** - the identifier of the feature including the platform bundles that will be available in the created update site (default: **'platform.feature'**)
 * **featureName** - the name of the feature including the platform bundles that will be available in the created update site (default: **'Generated platform feature'**)
@@ -445,7 +445,7 @@ platform {
 	fetchSources = false
 	featureVersion = '3.1.0'
 	eclipseHome = new File('/opt/eclipse')
-	eclipseMirror.linux.gtk.x86_64 = 'http://myeclipsedownload.com/eclipse.tar.gz'
+	eclipseMirror = 'http://myeclipsedownload.com/eclipse.tar.gz'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,8 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 apply plugin: 'eclipse'
 apply plugin: 'com.jfrog.bintray'
+apply plugin: 'maven-publish'
+
 
 repositories {
 	jcenter()
@@ -173,5 +175,16 @@ bintray { // task bintrayUpload
 		}
 	}
 
+}
+
+publishing {
+    publications {
+        MyPublication(MavenPublication) {
+            from components.java
+            groupId "${group}"
+            artifactId 'bnd-platform'
+            version "${version}"
+        }
+    }
 }
 

--- a/minimal-product.product
+++ b/minimal-product.product
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?pde version="3.5"?>
+
+<product uid="minimal-product" useFeatures="false" includeLaunchers="true">
+
+   <configIni use="default">
+   </configIni>
+
+   <launcherArgs>
+      <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
+      </vmArgsMac>
+   </launcherArgs>
+
+   <plugins>
+      <plugin id="javax.xml"/>
+      <plugin id="org.apache.felix.gogo.command"/>
+      <plugin id="org.apache.felix.gogo.runtime"/>
+      <plugin id="org.apache.felix.scr"/>
+      <plugin id="org.eclipse.core.contenttype"/>
+      <plugin id="org.eclipse.core.jobs"/>
+      <plugin id="org.eclipse.core.runtime"/>
+      <plugin id="org.eclipse.equinox.app"/>
+      <plugin id="org.eclipse.equinox.common"/>
+      <plugin id="org.eclipse.equinox.ds"/>
+      <plugin id="org.eclipse.equinox.event"/>
+      <plugin id="org.eclipse.equinox.frameworkadmin"/>
+      <plugin id="org.eclipse.equinox.frameworkadmin.equinox"/>
+      <plugin id="org.eclipse.equinox.p2.artifact.repository"/>
+      <plugin id="org.eclipse.equinox.p2.core"/>
+      <plugin id="org.eclipse.equinox.p2.jarprocessor"/>
+      <plugin id="org.eclipse.equinox.p2.metadata"/>
+      <plugin id="org.eclipse.equinox.p2.metadata.repository"/>
+      <plugin id="org.eclipse.equinox.p2.publisher"/>
+      <plugin id="org.eclipse.equinox.p2.publisher.eclipse"/>
+      <plugin id="org.eclipse.equinox.p2.repository"/>
+      <plugin id="org.eclipse.equinox.p2.updatesite"/>
+      <plugin id="org.eclipse.equinox.preferences"/>
+      <plugin id="org.eclipse.equinox.registry"/>
+      <plugin id="org.eclipse.equinox.security"/>
+      <plugin id="org.eclipse.equinox.security.linux.x86_64" fragment="true"/>
+      <plugin id="org.eclipse.equinox.simpleconfigurator"/>
+      <plugin id="org.eclipse.equinox.simpleconfigurator.manipulator"/>
+      <plugin id="org.eclipse.equinox.weaving.hook" fragment="true"/>
+      <plugin id="org.eclipse.osgi"/>
+      <plugin id="org.eclipse.osgi.compatibility.state" fragment="true"/>
+      <plugin id="org.eclipse.osgi.services"/>
+      <plugin id="org.eclipse.osgi.util"/>
+      <plugin id="org.tukaani.xz"/>
+   </plugins>
+
+   <configurations>
+      <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="0" />
+      <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />
+      <plugin id="org.eclipse.equinox.ds" autoStart="true" startLevel="2" />
+      <plugin id="org.eclipse.equinox.event" autoStart="true" startLevel="2" />
+      <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
+   </configurations>
+
+</product>

--- a/src/main/groovy/org/standardout/gradle/plugin/platform/PlatformPlugin.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/PlatformPlugin.groovy
@@ -340,37 +340,24 @@ public class PlatformPlugin implements Plugin<Project> {
 	}
 
 	private void downloadAndExtractEclipse(File downloadsDir) {
-		// download and extract Eclipse
-		def artifacts = project.platform.eclipseMirror
-		if (artifacts.containsKey(project.ext.osgiOS) && artifacts[project.ext.osgiOS].containsKey(project.ext.osgiWS) &&
-			artifacts[project.ext.osgiOS][project.ext.osgiWS].containsKey(project.ext.osgiArch)) {
-
-			// Download artifact
-			String artifactDownloadUrl = artifacts[project.ext.osgiOS][project.ext.osgiWS][project.ext.osgiArch]
-			def filename = artifactDownloadUrl.substring(artifactDownloadUrl.lastIndexOf('/') + 1)
-			def artifactZipPath = new File(downloadsDir, filename)
-			def artifactZipPathPart = new File(downloadsDir, filename + '.part')
-			if (!artifactZipPath.exists()) {
-				project.download {
-					src artifactDownloadUrl
-					dest artifactZipPathPart
-					overwrite true
-				}
-				artifactZipPathPart.renameTo(artifactZipPath)
+		// Download artifact
+		def artifactDownloadUrl = project.platform.eclipseMirror
+		def filename = artifactDownloadUrl.substring(artifactDownloadUrl.lastIndexOf('/') + 1)
+		def artifactZipPath = new File(downloadsDir, filename)
+		def artifactZipPathPart = new File(downloadsDir, filename + '.part')
+		if (!artifactZipPath.exists()) {
+			project.download {
+				src artifactDownloadUrl
+				dest artifactZipPathPart
+				overwrite true
 			}
+			artifactZipPathPart.renameTo(artifactZipPath)
+		}
 
-			// Unzip artifact
-			println('Copying ' + artifactZipPath + ' ...')
-			def artifactInstallPath = downloadsDir
-			if (artifactZipPath.name.endsWith('.zip')) {
-				project.ant.unzip(src: artifactZipPath, dest: artifactInstallPath)
-			} else {
-				project.ant.untar(src: artifactZipPath, dest: artifactInstallPath, compression: 'gzip')
-			}
-		}
-		else {
-			project.logger.error 'Unable to download eclipse artifact'
-		}
+		// Unzip artifact
+		println('Copying ' + artifactZipPath + ' ...')
+		def artifactInstallPath = downloadsDir
+		project.ant.untar(src: artifactZipPath, dest: artifactInstallPath, compression: 'gzip')
 	}
 
 	private File checkDownloadedEclipse(File downloadsDir) {

--- a/src/main/groovy/org/standardout/gradle/plugin/platform/PlatformPluginExtension.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/PlatformPluginExtension.groovy
@@ -308,32 +308,10 @@ class PlatformPluginExtension {
 	File downloadsDir
 
 	/**
-	 * Nested map that is checked for Eclipse download URLs, keys are
-	 * osgiOS (win32, linux, macosx), osgiWS (win32, gtk, cocoa) and
-	 * arch (x86, x86_64) in that order.
-	 * Specify an alternate Eclipse mirror like this:
-	 * <code>eclipseMirror.win32.win32.x86 = 'http://...'</code>   
+	 * 4.8 MB *.tar.gz file, which contains the minimal setup of eclipse plug-ins,
+	 * which are necessary to build an eclipse p2 update site.
 	 */
-	def eclipseMirror = [
-		win32: [
-			win32: [
-				x86: 'http://ftp.fau.de/eclipse/technology/epp/downloads/release/indigo/SR2/eclipse-rcp-indigo-SR2-win32.zip',
-				x86_64: 'http://ftp.fau.de/eclipse/technology/epp/downloads/release/indigo/SR2/eclipse-rcp-indigo-SR2-win32-x86_64.zip'
-			]
-		],
-		linux: [
-			gtk: [
-				x86: 'http://ftp.fau.de/eclipse/technology/epp/downloads/release/indigo/SR2/eclipse-rcp-indigo-SR2-linux-gtk.tar.gz',
-				x86_64: 'http://ftp.fau.de/eclipse/technology/epp/downloads/release/indigo/SR2/eclipse-rcp-indigo-SR2-linux-gtk-x86_64.tar.gz'
-			]
-		],
-		macosx: [
-			cocoa: [
-				x86: 'http://ftp.fau.de/eclipse/technology/epp/downloads/release/indigo/SR2/eclipse-rcp-indigo-SR2-macosx-cocoa.tar.gz',
-				x86_64: 'http://ftp.fau.de/eclipse/technology/epp/downloads/release/indigo/SR2/eclipse-rcp-indigo-SR2-macosx-cocoa-x86_64.tar.gz'
-			]
-		]
-	]
+	def eclipseMirror = 'https://dl.bintray.com/simon-scholz/eclipse-apps/eclipse-p2-minimal.tar.gz'
 	
 	/**
 	 * Call feature to create a feature configuration.

--- a/src/main/groovy/org/standardout/gradle/plugin/platform/internal/util/bnd/BndHelper.java
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/internal/util/bnd/BndHelper.java
@@ -17,8 +17,11 @@
 package org.standardout.gradle.plugin.platform.internal.util.bnd;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.jar.Manifest;
@@ -27,8 +30,12 @@ import java.util.zip.ZipFile;
 
 import aQute.bnd.osgi.Analyzer;
 import aQute.bnd.osgi.Builder;
+import aQute.bnd.osgi.Constants;
+import aQute.bnd.osgi.Instruction;
+import aQute.bnd.osgi.Instructions;
 import aQute.bnd.osgi.Jar;
 import aQute.bnd.osgi.Resource;
+import aQute.libg.tuple.Pair;
 
 /**
  * Utilities for working with bnd.
@@ -36,7 +43,7 @@ import aQute.bnd.osgi.Resource;
  * @author Simon Templer
  */
 public class BndHelper {
-	
+
 	/**
 	 * Create a default builder.
 	 */
@@ -45,51 +52,51 @@ public class BndHelper {
 		b.setTrace(false);
 		b.setPedantic(true);
 		b.setFailOk(false);
-		
+
 		return b;
 	}
-	
+
 	/**
-	 * Build the bnd configuration present in the given builder and write the
-	 * bundle to the target file.
-	 *  
-	 * @param b the builder
+	 * Build the bnd configuration present in the given builder and write the bundle
+	 * to the target file.
+	 * 
+	 * @param b      the builder
 	 * @param target the target file
 	 * @throws Exception if creating the bundle fails
 	 */
 	public static void buildAndClose(Builder b, File target) throws Exception {
 		try {
 			b.build();
-	
+
 			if (b.isOk()) {
 				b.save(target, true);
 				if (!b.isOk()) {
 					target.delete();
 					throw new IllegalStateException("Failed to save bundled jar");
 				}
-			}
-			else {
+			} else {
 				throw new IllegalStateException("Failed to build bnd configuration");
 			}
 		} finally {
 			b.close();
 		}
 	}
-	
+
 	/**
-	 * Wrap a Jar as it is, only changing the manifest. 
-	 * @param source the source jar
-	 * @param classpath the class path
-	 * @param target the target file 
+	 * Wrap a Jar as it is, only changing the manifest.
+	 * 
+	 * @param source     the source jar
+	 * @param classpath  the class path
+	 * @param target     the target file
 	 * @param properties the bnd properties
 	 * @return if the target file was created, it will not be created if the source
-	 *   Jar is empty or invalid
+	 *         Jar is empty or invalid
 	 * @throws Exception if wrapping the Jar fails
 	 */
-	public static boolean wrap(File source, Collection<File> classpath, File target,
-			Map<String, String> properties, boolean removeSignature) throws Exception {
+	public static boolean wrap(File source, Collection<File> classpath, File target, Map<String, String> properties,
+			boolean removeSignature) throws Exception {
 		File file = source;
-		
+
 		// test file
 		try (ZipFile zip = new ZipFile(file)) {
 			// (actually we never get here if it is empty)
@@ -117,7 +124,7 @@ public class BndHelper {
 			}
 
 			wrapper.setJar(file); // fails for empty JARs!
-			
+
 			if (removeSignature) {
 				doRemoveSignature(wrapper.getJar());
 			}
@@ -128,7 +135,7 @@ public class BndHelper {
 			// defaults
 			wrapper.setImportPackage("*;resolution:=optional");
 			wrapper.setExportPackage("*");
-			
+
 			// custom properties
 			wrapper.addProperties(properties);
 
@@ -138,30 +145,68 @@ public class BndHelper {
 				if (wrapper.getErrors() != null && !wrapper.getErrors().isEmpty()) {
 					String name = wrapper.getBundleSymbolicName().getKey();
 					for (String error : wrapper.getErrors()) {
-						
-						System.out.println("Error reported by bundle wrapper for bundle "
-								+ name + " is ignored:\n" + error);
+
+						System.out.println(
+								"Error reported by bundle wrapper for bundle " + name + " is ignored:\n" + error);
 					}
 				}
-				
+
 				wrapper.getJar().setManifest(m);
 				wrapper.save(outputFile, true);
 				if (!wrapper.isOk() || !outputFile.exists()) {
 					throw new IllegalStateException("Failed creating a wrapped bundle");
 				}
+			} else {
+				throw new IllegalStateException(
+						"Failed calculating the manifest for a wrapped bundle: " + wrapper.getErrors());
 			}
-			else {
-				throw new IllegalStateException("Failed calculating the manifest for a wrapped bundle: "
-						+ wrapper.getErrors());
-			}
-		}
-		finally {
+		} finally {
 			wrapper.close();
 		}
-		
+
 		return true;
 	}
-	
+
+	/**
+	 * Creates a {@link Pair} with the {@value Constants#BUNDLE_SYMBOLICNAME} as
+	 * first value and a list of imported packages as second value of the given
+	 * bundle, but without meta data like version and others .
+	 * 
+	 * @param bundle {@link File} which is an OSGi bundle
+	 * @return {@link Pair} containing the bundle's Bundle-SymbolicName and a list
+	 *         of imported packages
+	 * @throws Exception
+	 */
+	public static Pair<String, List<String>> getSymbolicNameAndPackageImports(File bundle) throws Exception {
+		Jar jar = null;
+		try {
+			jar = new Jar(bundle);
+			Manifest manifest = jar.getManifest();
+
+			String bundleSymbolicname = manifest.getMainAttributes().getValue(Constants.BUNDLE_SYMBOLICNAME);
+
+			String importPackages = manifest.getMainAttributes().getValue(Constants.IMPORT_PACKAGE);
+			if (null == importPackages) {
+				List<String> emptyList = Collections.emptyList();
+				return Pair.newInstance(bundleSymbolicname, emptyList);
+			}
+
+			Instructions instructions = new Instructions(importPackages);
+			List<String> imports = new ArrayList<>(instructions.size());
+			Set<Instruction> instructionsKeySet = instructions.keySet();
+			for (Instruction instruction : instructionsKeySet) {
+				String input = instruction.getInput();
+				imports.add(input);
+			}
+
+			return Pair.newInstance(bundleSymbolicname, imports);
+		} finally {
+			if (jar != null) {
+				jar.close();
+			}
+		}
+	}
+
 	private static void doRemoveSignature(Jar jar) {
 		Map<String, Resource> metaInf = jar.getDirectories().get("META-INF");
 		Set<String> toRemove = new HashSet<String>();


### PR DESCRIPTION
Hi Simon,

I really appreciate your work and use your gradle plugin really often. Thank you for providing it.
I have created a damn small eclipse application to use the p2 command line applications and it's just 4.8 MB instead of 180 MB for the whole indigo sdk.

You can find it here: https://dl.bintray.com/simon-scholz/eclipse-apps/eclipse-p2-minimal.tar.gz

I would be happy if you merge this feature, since many customers of us use your gradle plugin and would be happy if they won't have to configure an eclipseHome property or even download the huge indigo sdk. 

Let me know if I can help with further stuff.

Best regards,

Simon