### PR TITLE
Derive from BasePlugin and use gradleHomeDir - resolves #45

### DIFF
--- a/src/main/groovy/org/standardout/gradle/plugin/platform/PlatformPlugin.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/PlatformPlugin.groovy
@@ -97,7 +97,7 @@ public class PlatformPlugin implements Plugin<Project> {
 			if (project.platform.downloadsDir == null) {
 				// use gradleUserHomeDir to store the minimal p2 eclipse distribution for generating p2 update sites
 				// See https://docs.gradle.org/current/dsl/org.gradle.api.invocation.Gradle.html#org.gradle.api.invocation.Gradle:gradleUserHomeDir
-				project.platform.downloadsDir = new File(project.gradle.gradleUserHomeDir, 'eclipse-downloads')
+				project.platform.downloadsDir = new File(project.gradle.gradleUserHomeDir, 'bnd-platform')
 			}
 			if (!project.platform.downloadsDir.exists()) {
 				project.platform.downloadsDir.mkdirs()

--- a/src/main/groovy/org/standardout/gradle/plugin/platform/PlatformPlugin.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/PlatformPlugin.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.plugins.BasePlugin
 import org.osgi.framework.Version
 import org.standardout.gradle.plugin.platform.internal.BundleArtifact;
 import org.standardout.gradle.plugin.platform.internal.BundlesAction;
@@ -32,7 +33,6 @@ import org.standardout.gradle.plugin.platform.internal.osdetect.SwtPlatform
 import org.standardout.gradle.plugin.platform.internal.util.FeatureUtil;
 import org.standardout.gradle.plugin.platform.internal.util.bnd.BndHelper
 
-import aQute.libg.tuple.Pair
 import groovy.io.FileType
 import groovy.json.JsonOutput
 
@@ -57,6 +57,9 @@ public class PlatformPlugin implements Plugin<Project> {
 	@Override
 	public void apply(Project project) {
 		this.project = project
+
+		// use BasePlugin to derive the clean task from it
+		project.getPluginManager().apply(BasePlugin.class);
 
 		configureEnvironment(project)
 
@@ -92,7 +95,9 @@ public class PlatformPlugin implements Plugin<Project> {
 			}
 
 			if (project.platform.downloadsDir == null) {
-				project.platform.downloadsDir = new File(project.buildDir, 'eclipse-downloads')
+				// use gradleUserHomeDir to store the minimal p2 eclipse distribution for generating p2 update sites
+				// See https://docs.gradle.org/current/dsl/org.gradle.api.invocation.Gradle.html#org.gradle.api.invocation.Gradle:gradleUserHomeDir
+				project.platform.downloadsDir = new File(project.gradle.gradleUserHomeDir, 'eclipse-downloads')
 			}
 			if (!project.platform.downloadsDir.exists()) {
 				project.platform.downloadsDir.mkdirs()
@@ -111,24 +116,6 @@ public class PlatformPlugin implements Plugin<Project> {
 
 		// define bundles task
 		bundlesTask.doFirst(new BundlesAction(project, bundlesDir))
-
-		/*
-		 * Clean task.
-		 */
-		Task cleanTask = project.tasks.findByPath('clean')
-		if (!cleanTask) {
-			// only create tas if it does not exist yet
-			cleanTask = project.task('clean');
-		}
-		cleanTask.doLast {
-			categoryFile.delete()
-			featuresDir.deleteDir()
-			bundlesDir.deleteDir()
-			// don't delete download in default clean
-			//			downloadsDir.deleteDir()
-			project.platform.updateSiteDir.deleteDir()
-			project.platform.updateSiteZipFile.delete()
-		}
 
 		/*
 		 * Generate a feature definition for the platform feature.


### PR DESCRIPTION
When using bnd-platform plug-in together with other plug-ins, which are
derived from BasePlugin Gradle shows a warning that overriding the clean
task won't be allowed any more when using Gradle 5 or above. Therefore
the clean task of the BasePlugin is also being used and the
eclipse-downloads directory is stored in the gradleHomeDir (See
https://docs.gradle.org/current/dsl/org.gradle.api.invocation.Gradle.html#org.gradle.api.invocation.Gradle:gradleUserHomeDir
)

Change-Id: Ie5a2278b3042b6c86bda9a99bc878e1841afcfe2
Signed-off-by: Simon Scholz <simon.scholz@vogella.com>