### PR TITLE
Feature/make general feature optional

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,14 @@
  - Don't fail when merging Jars w/o manifest file - @qqilihq
  - remove 'Export-Package', 'Import-Package', 'Private-Package' for source bundle - @missedone
  - Prevent duplication of SNAPSHOT source bundles - @florianesser
+ - If no 'eclipseHome' is defined eclipse indigo is not downloaded any more, but a minimal eclipse app with a size of 4.8 MB. @SimonScholz
+ - The build folder does not have a eclipse-downloads folder any more, but the minimal eclipse app is stored in the gradleHomeDir, where the Gradle wrappers and other Gradle configurations are stored. @SimonScholz
+ - A new task called 'potentialOptionalImports' has been added. (See README for further information) @SimonScholz
+ - Public tasks are now more visible under the bnd-platform group when calling the 'tasks' task. @SimonScholz
+ - The Gradle wrapper of this project has been updated to Gradle 4.6 @SimonScholz
+ - The bnd-platform plug-in now applies Gradle's BasePlugin and therefore reuses the 'clean' task from Gradle's BasePlugin, therefore it integrates with other plug-ins more smoothly and will support Gradle 5 better, which does not allow to have a custom clean task. @SimonScholz
+ - The 'platform' closure now has a 'generatePlatformFeature' which states if a general feature should be created. In case custom features are generated you might not want to have an additional "generated platform feature" besides your own features. (default: **true**) @SimonScholz
+
 
 ### 1.5.0
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Alternatives are including the repository content in the **buildSrc** folder as 
 The **platform** plugin comes with several Gradle tasks - the following are the main tasks and build upon each other:
 
 * ***bundles*** - create bundles and write them to **build/plugins**
+* ***potentialOptionalImports*** Creates a potentialOptionalImports.txt file of imported packages of all generated bundles with the optionalImport instruction (See "Optional Dependencies" section below) 
 * ***updateSite*** - create a p2 repository from the bundles and write it to **build/updatesite** (default)
 * ***updateSiteZip*** - create a ZIP archive from the p2 repository and write it to **build/updatesite.zip** (default)
 
@@ -445,6 +446,7 @@ Via the platform extension there are several settings you can provide:
 * **eclipseHome** - File object pointing to the directory of a local Eclipse installation to be used for generating the p2 repository (default: `null`)
 * **eclipseMirror** - Eclipse download URLs to be used when no local installation is provided via *eclipseHome*. Uses https://dl.bintray.com/simon-scholz/eclipse-apps/eclipse-p2-minimal.tar.gz by default.
 * **downloadsDir** -  the directory to store the downloaded Eclipse installation on local, this works if *eclipseHome* is not specified. (default: `new File(buildDir, 'eclipse-downloads')`)
+* **generatePlatformFeature** - States if a general feature should be created. In case custom features are generated you might not want to have an additional "generated platform feature" besides your own features. (default: **true**)
 * **featureId** - the identifier of the feature including the platform bundles that will be available in the created update site (default: **'platform.feature'**)
 * **featureName** - the name of the feature including the platform bundles that will be available in the created update site (default: **'Generated platform feature'**)
 * **featureVersion** - the version number for the feature including the platform bundles that will be available in the created update site (defaults to the project version)

--- a/src/main/groovy/org/standardout/gradle/plugin/platform/PlatformPlugin.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/PlatformPlugin.groovy
@@ -118,28 +118,22 @@ public class PlatformPlugin implements Plugin<Project> {
 		bundlesTask.doFirst(new BundlesAction(project, bundlesDir))
 
 		/*
-		 * Generate a feature definition for the platform feature.
+		 * Generate a default feature definition for the platform feature.
 		 */
 		Task platformFeatureTask = project.task('platformFeature', dependsOn: bundlesTask).doFirst {
 			// create platform feature.xml
-			Feature feature = new DefaultFeature(
-					id: project.platform.featureId,
-					label: project.platform.featureName,
-					version: project.platform.featureVersion,
-					providerName: project.platform.featureProvider,
-					bundles: project.platform.artifacts.values().toList(),
-					includedFeatures: project.platform.features.values().toList(),
-					project: project
-					)
-
-			project.platform.features[feature.id] = feature
+			generatePlatformFeature();
 		}
 
 		/*
 		 * Create JARs for all features. 
 		 */
-		Task bundleFeaturesTask = project.task('bundleFeatures', dependsOn: platformFeatureTask).doFirst {
+		Task bundleFeaturesTask = project.task('bundleFeatures', dependsOn: bundlesTask).doFirst {
 			featuresDir.mkdirs()
+
+			if(project.platform.generatePlatformFeature) {
+				generatePlatformFeature();
+			}
 
 			project.platform.features.values().each { Feature feature ->
 				File featureJar = new File(featuresDir, "${feature.id}_${feature.version}.jar")
@@ -408,4 +402,22 @@ See https://github.com/stempler/bnd-platform/issues/19#issuecomment-253797523
 
 		return null;
 	}
+
+	/**
+	 * Generate a default feature definition for the platform feature.
+	 */
+	private void generatePlatformFeature() {
+		Feature feature = new DefaultFeature(
+			id: project.platform.featureId,
+			label: project.platform.featureName,
+			version: project.platform.featureVersion,
+			providerName: project.platform.featureProvider,
+			bundles: project.platform.artifacts.values().toList(),
+			includedFeatures: project.platform.features.values().toList(),
+			project: project
+			)
+
+		project.platform.features[feature.id] = feature
+	}
+
 }

--- a/src/main/groovy/org/standardout/gradle/plugin/platform/PlatformPluginExtension.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/PlatformPluginExtension.groovy
@@ -254,6 +254,13 @@ class PlatformPluginExtension {
 	boolean removeSignaturesFromWrappedBundles = true
 	
 	/**
+	 * States if a general feature should be created. By default it's turned on and called Generated platform feature.
+	 * In case custom features are generated you might not want to have an additional "generated platform feature"
+	 * besides your own features.
+	 */
+	boolean generatePlatformFeature = true
+	
+	/**
 	 * The ID for the platform feature.
 	 */
 	String featureId = 'platform.feature'


### PR DESCRIPTION
Hi,

I usually use features (https://github.com/stempler/bnd-platform#defining-features-since-11) and therefore do not want to have the "Generated platform feature" in my category.

In order to be able to omit this "Generated platform feature" in my category I've added a generatePlatformFeature boolean, which defaults to true, so that the default behavior stays the same, but allows me to only have my own features when setting generatePlatformFeature = false.