### PR TITLE
Made extractPomInfo optional by adding the extractPomInformation variable

### DIFF
--- a/src/main/groovy/org/standardout/gradle/plugin/platform/PlatformPluginExtension.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/PlatformPluginExtension.groovy
@@ -112,6 +112,11 @@ class PlatformPluginExtension {
 	final Project project
 	
 	/**
+	 * States if additional configuration information from POM is desired.
+	 */
+	boolean extractPomInformation = true
+
+	/**
 	 * States if source for external dependencies should be fetched and corresponding source bundles created. 
 	 */
 	boolean fetchSources = true

--- a/src/main/groovy/org/standardout/gradle/plugin/platform/internal/ResolvedBundleArtifact.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/internal/ResolvedBundleArtifact.groovy
@@ -193,7 +193,7 @@ class ResolvedBundleArtifact implements BundleArtifact, DependencyArtifact {
 		
 		// determine additional configuration from information in POM
 		StoredConfig pomConfig = null
-		if (!source) {
+		if (!source && project.platform.extractPomInformation) {
 			pomInfo = extractPomInfo(group: group, name: name, version: version, project)
 			if (pomInfo) {
 				pomConfig = pomInfo.toStoredConfig()


### PR DESCRIPTION
I think it is a nice way to avoid searching for POM information when it's not desired.