### PR TITLE
Make use of http instead of https

### DIFF
--- a/src/main/groovy/org/standardout/gradle/plugin/platform/PlatformPluginExtension.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/PlatformPluginExtension.groovy
@@ -323,7 +323,7 @@ class PlatformPluginExtension {
 	 * 4.8 MB *.tar.gz file, which contains the minimal setup of eclipse plug-ins,
 	 * which are necessary to build an eclipse p2 update site.
 	 */
-	def eclipseMirror = 'https://dl.bintray.com/simon-scholz/eclipse-apps/eclipse-p2-minimal.tar.gz'
+	def eclipseMirror = 'http://dl.bintray.com/simon-scholz/eclipse-apps/eclipse-p2-minimal.tar.gz'
 	
 	/**
 	 * Call feature to create a feature configuration.


### PR DESCRIPTION
It seems that bintray has problems with the ssl certificates and for our
purposes we do not need ssl here.

Change-Id: Ibe175cbfb1840fd616ef2f3dd551309d3096a093
Signed-off-by: Simon Scholz <simon.scholz@vogella.com>