### PR TITLE
fix: prevent ClassCastException in case of new artifactVersion

### DIFF
--- a/src/main/groovy/org/standardout/gradle/plugin/platform/internal/util/DefaultQualifierMap.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/internal/util/DefaultQualifierMap.groovy
@@ -81,7 +81,7 @@ class DefaultQualifierMap implements VersionQualifierMap {
 		def artifactVersion = artifact[versionString]
 		if (!artifactVersion) {
 			artifactVersion = [:]
-			artifact[version] = artifactVersion
+			artifact[versionString] = artifactVersion
 		}
 		
 		// sort existing qualifiers, qualifiers mapped to idents


### PR DESCRIPTION
I ran into the exception below when updating an artifact with a new version:

```
Caused by: java.lang.ClassCastException: org.osgi.framework.Version cannot be cast to java.lang.String
        at org.standardout.gradle.plugin.platform.internal.util.DefaultQualifierMap.getQualifier(DefaultQualifierMap.groovy:84)
        at org.standardout.gradle.plugin.platform.internal.util.VersionQualifierMap$getQualifier.call(Unknown Source)
        at org.standardout.gradle.plugin.platform.internal.util.VersionUtil.addQualifier(VersionUtil.groovy:209)
        at org.standardout.gradle.plugin.platform.internal.util.VersionUtil$addQualifier$0.call(Unknown Source)
        at org.standardout.gradle.plugin.platform.internal.config.ArtifactFeature.getVersion(ArtifactFeature.groovy:114)
        at org.standardout.gradle.plugin.platform.PlatformPlugin$_apply_closure4$_closure13.doCall(PlatformPlugin.groovy:139)
        at org.standardout.gradle.plugin.platform.PlatformPlugin$_apply_closure4.doCall(PlatformPlugin.groovy:138)
        at org.gradle.api.internal.AbstractTask$ClosureTaskAction.execute(AbstractTask.java:739)
        at org.gradle.api.internal.AbstractTask$ClosureTaskAction.execute(AbstractTask.java:712)
        at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter$1.run(ExecuteActionsTaskExecuter.java:131)
        at org.gradle.internal.operations.DefaultBuildOperationExecutor$RunnableBuildOperationWorker.execute(DefaultBuildOperationExecutor.java:300)
        at org.gradle.internal.operations.DefaultBuildOperationExecutor$RunnableBuildOperationWorker.execute(DefaultBuildOperationExecutor.java:292)
        at org.gradle.internal.operations.DefaultBuildOperationExecutor.execute(DefaultBuildOperationExecutor.java:174)
        at org.gradle.internal.operations.DefaultBuildOperationExecutor.run(DefaultBuildOperationExecutor.java:90)
        at org.gradle.internal.operations.DelegatingBuildOperationExecutor.run(DelegatingBuildOperationExecutor.java:31)
        at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeAction(ExecuteActionsTaskExecuter.java:120)
        at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeActions(ExecuteActionsTaskExecuter.java:99)
        ... 111 more
```

