### PR TITLE
Enable specifying ws/os/arch for plugins embedded in features

### DIFF
--- a/src/main/groovy/org/standardout/gradle/plugin/platform/internal/BundleArtifact.java
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/internal/BundleArtifact.java
@@ -56,6 +56,21 @@ public interface BundleArtifact {
 	String getModifiedVersion();
 	
 	/**
+	 * Target OS of the bundle.
+	 */
+	String getOs();
+
+	/**
+	 * Target Architecture of the bundle.
+	 */
+	String getArch();
+
+	/**
+	 * Allowed window subsystem of the bundle.
+	 */
+	String getWs();
+	
+	/**
 	 * Should the bundle be wrapped using bnd?
 	 */
 	boolean isWrap();

--- a/src/main/groovy/org/standardout/gradle/plugin/platform/internal/FileBundleArtifact.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/internal/FileBundleArtifact.groovy
@@ -51,6 +51,12 @@ class FileBundleArtifact implements BundleArtifact {
 	
 	BundleArtifact sourceBundle
 	
+	private final String os
+	
+	private final String arch
+	
+	private final String ws
+	
 	private final boolean source
 	
 	private final boolean wrap
@@ -106,6 +112,14 @@ class FileBundleArtifact implements BundleArtifact {
 				v = VersionUtil.addQualifier(v, symbolicName, bndConfig, project, customType)
 			}
 			version = modifiedVersion = VersionUtil.toOsgiVersion(v).toString()
+			
+			// Extract target platform constraints if present
+			def platformString = bndConfig.getInstruction('Eclipse-PlatformFilter')
+			if(platformString) {
+				ws = (platformString =~ /.*\(osgi\.ws\=(.*?)\).*/)[ 0 ][ 1 ]
+				os = (platformString =~ /.*\(osgi\.os\=(.*?)\).*/)[ 0 ][ 1 ]
+				arch = (platformString =~ /.*\(osgi\.arch\=(.*?)\).*/)[ 0 ][ 1 ]
+			}
 		}
 		else if (jarInfo && jarInfo.symbolicName && jarInfo.version) {
 			// only jar info present (and jar is bundle)
@@ -151,6 +165,18 @@ class FileBundleArtifact implements BundleArtifact {
 		bundle.sourceBundle = this
 	}
 	
+	@Override
+	public String getOs() {
+		os
+	}
+	@Override
+	public String getArch() {
+		arch
+	}
+	@Override
+	public String getWs() {
+		ws
+	}
 	@Override
 	public boolean isSource() {
 		source

--- a/src/main/groovy/org/standardout/gradle/plugin/platform/internal/ResolvedBundleArtifact.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/internal/ResolvedBundleArtifact.groovy
@@ -60,7 +60,16 @@ class ResolvedBundleArtifact implements BundleArtifact, DependencyArtifact {
 	
 	private String version
 	String getVersion() { version }
-
+	
+	private final String os
+	@Override public String getOs() { os }
+	
+	private final String arch
+	@Override public String getArch() { arch }
+	
+	private final String ws
+	@Override public String getWs() { ws }
+	
 	private final boolean source
 	boolean isSource() { source }
 	
@@ -240,6 +249,14 @@ class ResolvedBundleArtifact implements BundleArtifact, DependencyArtifact {
 			}
 			
 			addQualifier = !source // by default don't add qualifiers for source bundles
+			
+			// Extract target platform constraints if present
+			def platformString = bndConfig.getInstruction('Eclipse-PlatformFilter')
+			if(platformString) {
+				ws = (platformString =~ /.*\(osgi\.ws\=(.*?)\).*/)[ 0 ][ 1 ]
+				os = (platformString =~ /.*\(osgi\.os\=(.*?)\).*/)[ 0 ][ 1 ]
+				arch = (platformString =~ /.*\(osgi\.arch\=(.*?)\).*/)[ 0 ][ 1 ]
+			}
 		}
 		else if (wrap) {
 			addQualifier = !source // by default don't add qualifiers for source bundles

--- a/src/main/groovy/org/standardout/gradle/plugin/platform/internal/config/BndConfig.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/internal/config/BndConfig.groovy
@@ -122,6 +122,13 @@ class BndConfig {
 	}
 	
 	/**
+	 * Returns the value of the bnd instruction with the given name.
+	 */
+	def getInstruction(String name) {
+		properties[name]
+	}
+	
+	/**
 	 * Add packages for optional import.
 	 */
 	def optionalImport(String... packages) {

--- a/src/main/groovy/org/standardout/gradle/plugin/platform/internal/util/FeatureUtil.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/internal/util/FeatureUtil.groovy
@@ -58,12 +58,23 @@ class FeatureUtil {
 			// included bundles
 			for (BundleArtifact artifact : feature.bundles.sort(true, { it.symbolicName })) {
 				// define each plug-in
-				plugin(
-					id: artifact.symbolicName,
+				def paramMap = [
+					'id': artifact.symbolicName,
 					'download-size': 0,
 					'install-size': 0,
 					version: artifact.modifiedVersion,
-					unpack: false)
+					unpack: false]
+				
+				// omit empty/null for os/arch/ws (may not be present)
+				if(artifact.os) {
+					paramMap.put('os', artifact.os)
+				} else if(artifact.arch) {
+					paramMap.put('arch', artifact.arch)
+				} else if(artifact.ws) {
+					paramMap.put('ws', artifact.ws)
+				}
+
+				plugin(paramMap)
 			}
 		}
 	}


### PR DESCRIPTION
* The properties ws/os/arch are used in platform specific plugins as
  osgi filters to determine their applicability to a target platform.
  These are typically denoted by the manifest attribute
  "Eclipse-PlatformFilter".
* For features, the same property nodes are used to determine the
  applicable plugins.
* In order to make the generated features aware of these platform
  specification markers, extract them from bnd configurations and
  pass the extracted values to the feature builder.
* The plugin nodes of features omit the platform-specific flags if they
  were not present in the input artifact.

Signed-off-by: Alexander Diewald <diewald@fortiss.org>