### PR TITLE
Features: Fixes for platform-specific bundles

### DIFF
--- a/src/main/groovy/org/standardout/gradle/plugin/platform/internal/FileBundleArtifact.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/internal/FileBundleArtifact.groovy
@@ -71,6 +71,7 @@ class FileBundleArtifact implements BundleArtifact {
 		this.source = false // don't mark as source bundle so it is processed as usual
 		
 		boolean source = false
+		String platformFilter = null
 		
 		JarInfo jarInfo = null
 		boolean includeDefaultConfig = true
@@ -114,12 +115,7 @@ class FileBundleArtifact implements BundleArtifact {
 			version = modifiedVersion = VersionUtil.toOsgiVersion(v).toString()
 			
 			// Extract target platform constraints if present
-			def platformString = bndConfig.getInstruction('Eclipse-PlatformFilter')
-			if(platformString) {
-				ws = (platformString =~ /.*\(osgi\.ws\=(.*?)\).*/)[ 0 ][ 1 ]
-				os = (platformString =~ /.*\(osgi\.os\=(.*?)\).*/)[ 0 ][ 1 ]
-				arch = (platformString =~ /.*\(osgi\.arch\=(.*?)\).*/)[ 0 ][ 1 ]
-			}
+			platformFilter = bndConfig.getInstruction('Eclipse-PlatformFilter')
 		}
 		else if (jarInfo && jarInfo.symbolicName && jarInfo.version) {
 			// only jar info present (and jar is bundle)
@@ -132,9 +128,18 @@ class FileBundleArtifact implements BundleArtifact {
 			else {
 				bundleName = symbolicName
 			}
+			
+			platformFilter = jarInfo.platformFilter
 		}
 		else {
 			throw new IllegalStateException('A file dependency must either already be a bundle or a bnd configuration including version and symbolicName must be specified: ' + file)
+		}
+		
+		// Extract target platform constraints if present
+		if(platformFilter) {
+			ws = (jarInfo.platformFilter =~ /.*\(osgi\.ws\=(.*?)\).*/)[ 0 ][ 1 ]
+			os = (jarInfo.platformFilter =~ /.*\(osgi\.os\=(.*?)\).*/)[ 0 ][ 1 ]
+			arch = (jarInfo.platformFilter =~ /.*\(osgi\.arch\=(.*?)\).*/)[ 0 ][ 1 ]
 		}
 		
 		this.targetFileName = symbolicName + '_' + modifiedVersion + '.jar'

--- a/src/main/groovy/org/standardout/gradle/plugin/platform/internal/ResolvedBundleArtifact.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/internal/ResolvedBundleArtifact.groovy
@@ -142,6 +142,9 @@ class ResolvedBundleArtifact implements BundleArtifact, DependencyArtifact {
 			// but different classifier
 			symbolicName += '.' + classifier
 		}
+		
+		// Platform-Filter (if available)
+		String platformFilter = null
 				
 		// reason why a bundle is not wrapped
 		JarInfo jarInfo = null
@@ -250,13 +253,7 @@ class ResolvedBundleArtifact implements BundleArtifact, DependencyArtifact {
 			
 			addQualifier = !source // by default don't add qualifiers for source bundles
 			
-			// Extract target platform constraints if present
-			def platformString = bndConfig.getInstruction('Eclipse-PlatformFilter')
-			if(platformString) {
-				ws = (platformString =~ /.*\(osgi\.ws\=(.*?)\).*/)[ 0 ][ 1 ]
-				os = (platformString =~ /.*\(osgi\.os\=(.*?)\).*/)[ 0 ][ 1 ]
-				arch = (platformString =~ /.*\(osgi\.arch\=(.*?)\).*/)[ 0 ][ 1 ]
-			}
+			platformFilter = bndConfig.getInstruction('Eclipse-PlatformFilter')
 		}
 		else if (wrap) {
 			addQualifier = !source // by default don't add qualifiers for source bundles
@@ -273,6 +270,13 @@ class ResolvedBundleArtifact implements BundleArtifact, DependencyArtifact {
 		if (aux && project.platform.auxVersionedSymbolicNames) {
 			symbolicName = symbolicName + '-' + version // augment with (original) version
 			wrap = true // force wrap
+		}
+		
+		// Extract target platform constraints if present
+		if(platformFilter) {
+			ws = (jarInfo.platformFilter =~ /.*\(osgi\.ws\=(.*?)\).*/)[ 0 ][ 1 ]
+			os = (jarInfo.platformFilter =~ /.*\(osgi\.os\=(.*?)\).*/)[ 0 ][ 1 ]
+			arch = (jarInfo.platformFilter =~ /.*\(osgi\.arch\=(.*?)\).*/)[ 0 ][ 1 ]
 		}
 		
 		this.modifiedVersion = modifiedVersion

--- a/src/main/groovy/org/standardout/gradle/plugin/platform/internal/util/FeatureUtil.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/internal/util/FeatureUtil.groovy
@@ -68,9 +68,11 @@ class FeatureUtil {
 				// omit empty/null for os/arch/ws (may not be present)
 				if(artifact.os) {
 					paramMap.put('os', artifact.os)
-				} else if(artifact.arch) {
+				}
+				if(artifact.arch) {
 					paramMap.put('arch', artifact.arch)
-				} else if(artifact.ws) {
+				} 
+				if(artifact.ws) {
 					paramMap.put('ws', artifact.ws)
 				}
 

--- a/src/main/groovy/org/standardout/gradle/plugin/platform/internal/util/bnd/JarInfo.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/internal/util/bnd/JarInfo.groovy
@@ -34,6 +34,7 @@ class JarInfo {
 		Analyzer.IMPORT_PACKAGE,
 		Analyzer.BUNDLE_LICENSE,
 		Analyzer.BUNDLE_VENDOR,
+		'Eclipse-PlatformFilter',
 		'Eclipse-SourceBundle' // to be able to identify a source bundle
 	] as Set).asImmutable()
 
@@ -42,6 +43,8 @@ class JarInfo {
 	final String symbolicName
 	
 	final String bundleName
+	
+	final String platformFilter;
 	
 	final String version
 	
@@ -63,12 +66,14 @@ class JarInfo {
 			bundleName = main.getValue(Analyzer.BUNDLE_NAME)
 			version = main.getValue(Analyzer.BUNDLE_VERSION)
 			symbolicName = extractSymbolicName(main.getValue(Analyzer.BUNDLE_SYMBOLICNAME))
+			platformFilter = main.getValue('Eclipse-PlatformFilter')
 		}
 		else {
 			// the Jar has no manifest
 			bundleName = null
 			version = null
 			symbolicName = null
+			platformFilter = null
 		}
 		
 		instructions = properties.asImmutable() 


### PR DESCRIPTION
This PR resolves two bugs from the commit 11c632b0c1e397c32a4e0675d05ea11fe3880128.

Commit 1de118632bacfd5c397f617178c1c14c24c6da77 enables wrapped bundles to "passthrough" the platform filter variables. I did not notice this problem before since we were not using this feature at the time of implementing the first PR.

Commit d6f37ea0a88c1677f85644c8b150bad2ec601e06 resolves the problem of generating only the "OS" field in feature.xml files. Here, I fell for a very specific caching problem (now resolved), that covered the bug after prettifying the sources and rebuilding.