### PR TITLE
Added support for feature license

### DIFF
--- a/src/main/groovy/org/standardout/gradle/plugin/platform/internal/DefaultFeature.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/internal/DefaultFeature.groovy
@@ -26,6 +26,7 @@ class DefaultFeature implements Feature {
 	String label
 	String version
 	String providerName
+	String license
 	List<BundleArtifact> bundles = []
 	List<Feature> includedFeatures = []
 	Project project

--- a/src/main/groovy/org/standardout/gradle/plugin/platform/internal/Feature.java
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/internal/Feature.java
@@ -31,6 +31,8 @@ public interface Feature {
 	public String getVersion();
 	
 	public String getProviderName();
+
+	public String getLicense();
 	
 	public Iterable<BundleArtifact> getBundles();
 	

--- a/src/main/groovy/org/standardout/gradle/plugin/platform/internal/config/ArtifactFeature.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/internal/config/ArtifactFeature.groovy
@@ -42,6 +42,7 @@ class ArtifactFeature implements Feature {
 	final String label
 	final String version
 	final String providerName
+	final String license
 	
 	/**
 	 * List of artifact references
@@ -63,6 +64,7 @@ class ArtifactFeature implements Feature {
 		def label
 		def version
 		def providerName
+		def license
 		
 		// extract basic feature information from feature notation
 		if (featureNotation instanceof Map) {
@@ -70,6 +72,7 @@ class ArtifactFeature implements Feature {
 			label = featureNotation.name
 			version = featureNotation.version
 			providerName = featureNotation.provider
+			license = featureNotation.license
 		}
 		else {
 			// assume String id and default values
@@ -89,6 +92,7 @@ class ArtifactFeature implements Feature {
 		this.providerName = providerName ?: project.platform.featureProvider
 		this.id = id
 		this.label = label ?: id
+		this.license = license ?: ""
 		
 		// create masking delegate to be able to intercept internal call results
 		Closure maskedConfig = null

--- a/src/main/groovy/org/standardout/gradle/plugin/platform/internal/util/FeatureUtil.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/internal/util/FeatureUtil.groovy
@@ -49,6 +49,9 @@ class FeatureUtil {
 			'provider-name': feature.providerName
 			// plugin: branding_plugin_id
 		) {
+			if (feature.license) {
+				license(feature.license)
+			}
 			// included features
 			for (Feature included : feature.includedFeatures.sort(true, { it.id })) {
 				def version = included.version?:'0.0.0'


### PR DESCRIPTION
We evaluate the bnd-platform plugin for building a updatesite of third party dependencies which are not provided on an updatesite. Therefore, we need to leverage the support of eclipse to specify a license per feature and have it displayed during installation.

This PR introduces support to additionally specify the license for a feature, which is then included in the feature.xml. As the license tag is optional, it is only created when specified for a feature.