### PR TITLE
omit configuration when creating source artifact dependency

### DIFF
--- a/src/main/groovy/org/standardout/gradle/plugin/platform/internal/util/gradle/DependencyHelper.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/internal/util/gradle/DependencyHelper.groovy
@@ -198,7 +198,7 @@ class DependencyHelper {
 				dep.moduleGroup, 
 				dep.moduleName, 
 				dep.moduleVersion, 
-				dep.configuration)
+				null)
             sourceDep.transitive = false
 			def artifact = new DefaultDependencyArtifact(sourceDep.name, "source", "jar", "sources", null)
             sourceDep.addArtifact(artifact)


### PR DESCRIPTION
conforming to gradle 6
fixes stempler/bnd-platform#68  caused by gradle/gradle#10532