### PR TITLE
Support building with Java 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,6 @@ buildscript {
 }
 
 apply plugin: 'groovy'
-apply plugin: 'maven'
 apply plugin: 'signing'
 apply plugin: 'eclipse'
 apply plugin: 'com.jfrog.bintray'
@@ -23,8 +22,8 @@ repositories {
 group = 'org.standardout'
 version = '1.9.0-SNAPSHOT'
 
-sourceCompatibility = '1.7'
-targetCompatibility = '1.7'
+sourceCompatibility = '1.8'
+targetCompatibility = '1.8'
 
 jar {
 	// include license into jar
@@ -34,16 +33,16 @@ jar {
 }
 
 dependencies {
-	compile gradleApi()
-	compile 'biz.aQute.bnd:biz.aQute.bndlib:3.5.0'
-	compile 'org.osgi:osgi.core:6.0.0'
-	compile 'commons-io:commons-io:2.4'
-	compile 'de.undercouch:gradle-download-task:3.1.1'
-	compile localGroovy()
+	implementation gradleApi()
+	implementation 'biz.aQute.bnd:biz.aQute.bndlib:5.2.0'
+	implementation 'org.osgi:osgi.core:6.0.0'
+	implementation 'commons-io:commons-io:2.4'
+	implementation 'de.undercouch:gradle-download-task:3.1.1'
+	implementation localGroovy()
 }
 
-task wrapper(type: Wrapper) {
-	gradleVersion = '4.6'
+wrapper {
+	gradleVersion = '5.3'
 }
 
 // package groovydoc into a jar file

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ repositories {
 }
 
 group = 'org.standardout'
-version = '1.8.0-SNAPSHOT'
+version = '1.9.0-SNAPSHOT'
 
 sourceCompatibility = '1.7'
 targetCompatibility = '1.7'

--- a/build.gradle
+++ b/build.gradle
@@ -100,13 +100,6 @@ def configurePom(def pom) {
    }
 }
 
-install {
-	repositories.mavenInstaller {
-		// ensure correct artifact ID when installing locally
-		configurePom(pom)
-	}
-}
-
 // sign all artifacts
 signing {
 	required {
@@ -114,25 +107,6 @@ signing {
 		gradle.taskGraph.hasTask('uploadArchives')
 	}
 	sign configurations.archives
-}
-
-uploadArchives {
-	repositories {
-		mavenDeployer {
-			// sign artifacts before upload
-			beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-			
-			// upload to sonatype OSS (snapshot/release)
-			repository(url: this.version.endsWith('-SNAPSHOT') ?
-					'https://oss.sonatype.org/content/repositories/snapshots' :
-					'https://oss.sonatype.org/service/local/staging/deploy/maven2') {
-				authentication(userName: this.hasProperty('sonatypeUsername') ? sonatypeUsername : '',
-					password: this.hasProperty('sonatypePassword') ? sonatypePassword : '')
-			}
-			
-			configurePom(pom)
-		}
-	}
 }
 
 // groovydoc task work-around
@@ -178,12 +152,50 @@ bintray { // task bintrayUpload
 }
 
 publishing {
+    repositories {
+        maven {
+            url = this.version.endsWith('-SNAPSHOT') ? 'https://oss.sonatype.org/content/repositories/snapshots' : 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
+            credentials {
+                username = this.hasProperty('sonatypeUsername') ? sonatypeUsername : ''
+                password = this.hasProperty('sonatypePassword') ? sonatypePassword : ''
+            }
+        }
+    }
     publications {
         MyPublication(MavenPublication) {
             from components.java
             groupId "${group}"
             artifactId 'bnd-platform'
             version "${version}"
+
+            pom {
+                name = 'bnd-platform'
+                packaging = 'jar'
+                description = 'Build OSGi bundles and Eclipse Update Sites from existing JARs, e.g. from Maven repositories (Plugin for Gradle)'
+                url = 'https://github.com/stempler/bnd-platform'
+
+                scm {
+                    url = 'scm:git:https://github.com/stempler/bnd-platform.git'
+                    connection = 'scm:git:https://github.com/stempler/bnd-platform.git'
+                    developerConnection = 'scm:git:https://github.com/stempler/bnd-platform.git'
+                }
+
+                licenses {
+                    license {
+                        name = 'The Apache Software License, Version 2.0'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                        distribution = 'repo'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id = 'stempler'
+                        name = 'Simon Templer'
+                        email = 'simon@templer.cc'
+                    }
+                }
+            }
         }
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Tue Apr 03 12:34:51 CEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-bin.zip

--- a/gradlew
+++ b/gradlew
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 ##############################################################################
 ##
@@ -33,11 +33,11 @@ DEFAULT_JVM_OPTS=""
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD="maximum"
 
-warn ( ) {
+warn () {
     echo "$*"
 }
 
-die ( ) {
+die () {
     echo
     echo "$*"
     echo
@@ -154,11 +154,19 @@ if $cygwin ; then
     esac
 fi
 
-# Split up the JVM_OPTS And GRADLE_OPTS values into an array, following the shell quoting and substitution rules
-function splitJvmOpts() {
-    JVM_OPTS=("$@")
+# Escape application args
+save () {
+    for i do printf %s\\n "$i" | sed "s/'/'\\\\''/g;1s/^/'/;\$s/\$/' \\\\/" ; done
+    echo " "
 }
-eval splitJvmOpts $DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS
-JVM_OPTS[${#JVM_OPTS[*]}]="-Dorg.gradle.appname=$APP_BASE_NAME"
+APP_ARGS=$(save "$@")
 
-exec "$JAVACMD" "${JVM_OPTS[@]}" -classpath "$CLASSPATH" org.gradle.wrapper.GradleWrapperMain "$@"
+# Collect all arguments for the java command, following the shell quoting and substitution rules
+eval set -- $DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS "\"-Dorg.gradle.appname=$APP_BASE_NAME\"" -classpath "\"$CLASSPATH\"" org.gradle.wrapper.GradleWrapperMain "$APP_ARGS"
+
+# by default we should be in the correct project dir, but when run from Finder on Mac, the cwd is wrong
+if [ "$(uname)" = "Darwin" ] && [ "$HOME" = "$PWD" ]; then
+  cd "$(dirname "$0")"
+fi
+
+exec "$JAVACMD" "$@"

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -49,7 +49,6 @@ goto fail
 @rem Get command-line arguments, handling Windows variants
 
 if not "%OS%" == "Windows_NT" goto win9xME_args
-if "%@eval[2+2]" == "4" goto 4NT_args
 
 :win9xME_args
 @rem Slurp the command line arguments.
@@ -60,11 +59,6 @@ set _SKIP=2
 if "x%~1" == "x" goto execute
 
 set CMD_LINE_ARGS=%*
-goto execute
-
-:4NT_args
-@rem Get arguments from the 4NT Shell from JP Software
-set CMD_LINE_ARGS=%$
 
 :execute
 @rem Setup the command line

--- a/src/main/groovy/org/standardout/gradle/plugin/platform/PlatformPlugin.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/PlatformPlugin.groovy
@@ -215,6 +215,15 @@ public class PlatformPlugin implements Plugin<Project> {
 	
 				assert project.platform.eclipseHome
 				def eclipseHome = project.platform.eclipseHome.absolutePath
+
+				def javaHome = project.platform.javaHome?.absolutePath
+				def javaBin
+				if (javaHome) {
+					javaBin = "${javaHome}/bin/java"
+				}
+				else {
+					javaBin = "java"
+				}
 	
 				// find launcher jar
 				def launcherFiles = project.ant.fileScanner {
@@ -223,7 +232,7 @@ public class PlatformPlugin implements Plugin<Project> {
 				def launcherJar = launcherFiles.iterator().next()
 				assert launcherJar
 	
-				project.logger.info "Using Eclipse at $eclipseHome for p2 repository generation."
+				project.logger.info "Using Java at $javaHome and Eclipse at $eclipseHome for p2 repository generation."
 	
 				/*
 				 * Documentation on Publisher:
@@ -235,7 +244,7 @@ public class PlatformPlugin implements Plugin<Project> {
 				def repoDirUri = URLDecoder.decode(project.platform.updateSiteDir.toURI().toString(), 'UTF-8')
 				def categoryFileUri = URLDecoder.decode(categoryFile.toURI().toString(), 'UTF-8')
 				project.exec {
-					commandLine 'java', '-jar', launcherJar,
+					commandLine "${javaBin}", '-jar', launcherJar,
 							'-application', 'org.eclipse.equinox.p2.publisher.FeaturesAndBundlesPublisher',
 							'-metadataRepository', repoDirUri,
 							'-artifactRepository', repoDirUri,
@@ -245,7 +254,7 @@ public class PlatformPlugin implements Plugin<Project> {
 	
 				// launch Publisher for category / site.xml
 				project.exec {
-					commandLine 'java', '-jar', launcherJar,
+					commandLine "${javaBin}", '-jar', launcherJar,
 							'-application', 'org.eclipse.equinox.p2.publisher.CategoryPublisher',
 							'-metadataRepository', repoDirUri,
 							'-categoryDefinition', categoryFileUri,

--- a/src/main/groovy/org/standardout/gradle/plugin/platform/PlatformPluginExtension.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/PlatformPluginExtension.groovy
@@ -313,6 +313,12 @@ class PlatformPluginExtension {
 	File eclipseHome
 
 	/**
+	 * The directory of a JDK installation to used for running Equinox Publisher. If none is specified,
+	 * the `java` binary available on the path is used.
+	 */
+	File javaHome
+
+	/**
 	 * The directory to store the downloaded Eclipse installation on local, 
 	 * this works if <code>eclipseHome</code> is not specified.
 	 * Default to <code>project.buildDir/eclipse-downloads</code>.


### PR DESCRIPTION
- upgrade Gradle to 5.3 and adapt to plugin/config changes
- make Java binary used for Publisher task configurable so that it can be run more easily on systems that have a different JDK version in the path
