### PR TITLE
fix: fix default eclipse mirror URL

### DIFF
--- a/src/main/groovy/org/standardout/gradle/plugin/platform/PlatformPluginExtension.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/PlatformPluginExtension.groovy
@@ -334,7 +334,7 @@ class PlatformPluginExtension {
 	 * XXX Above artifact creates update sites that are often missing plugins - reason is unclear.
 	 * Issue does not happen with recent eclipse versions (e.g. 2023-09) but attempts to create a new working minimal product failed. 
 	 */
-	def eclipseMirror = 'https://ftp.fau.de/eclipse/technology/epp/downloads/release/2023-09/R/eclipse-rcp-2023-09-R-linux-gtk-x86_64.tar.gz'
+	def eclipseMirror = 'https://archive.eclipse.org/technology/epp/downloads/release/2023-09/R/eclipse-rcp-2023-09-R-linux-gtk-x86_64.tar.gz'
 	
 	/**
 	 * Call feature to create a feature configuration.


### PR DESCRIPTION
...because previously used URL seems to be no longer available.