### PR TITLE
feat: support appending to existing p2 repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@ Via the platform extension there are several settings you can provide:
 * **fetchSources** - if sources for external dependencies should be fetched and source bundles created (default: **true**)
 * **updateSiteDir** - the directory the generated p2 repository is written to (default: `new File(buildDir, 'updatesite')`)
 * **updateSiteZipFile** - the target file for the zipped p2 repository (default: `new File(buildDir, 'updatesite.zip')`)
+* **appendUpdateSite** - if any the generated p2 repository should be appended to the one that already exists in **updateSiteDir** (default: `false`)
 * **eclipseHome** - File object pointing to the directory of a local Eclipse installation to be used for generating the p2 repository (default: `null`)
 * **eclipseMirror** - Eclipse download URLs to be used when no local installation is provided via *eclipseHome*. Since version 3 uses an Eclipse 2023-09 mirror by default.
 * **downloadsDir** -  the directory to store the downloaded Eclipse installation on local, this works if *eclipseHome* is not specified. (default: `new File(buildDir, 'eclipse-downloads')`)

--- a/src/main/groovy/org/standardout/gradle/plugin/platform/PlatformPluginExtension.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/PlatformPluginExtension.groovy
@@ -304,6 +304,11 @@ class PlatformPluginExtension {
 	 * The target file for the 'updateSiteZip' task.
 	 */
 	File updateSiteZipFile
+
+	/**
+	 * If the update site should be appended instead of over-written.
+	 */
+	boolean appendUpdateSite = false
 	
 	/**
 	 * The directory of a local Eclipse installation. If none is specified the


### PR DESCRIPTION
Enabling the new setting `appendUpdateSite` combines the created update site / p2 repository with one that is already present in the target location.