### PR TITLE
extracting ws/os/arch from platform filter fails

### DIFF
--- a/src/main/groovy/org/standardout/gradle/plugin/platform/internal/FileBundleArtifact.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/internal/FileBundleArtifact.groovy
@@ -137,9 +137,9 @@ class FileBundleArtifact implements BundleArtifact {
 		
 		// Extract target platform constraints if present
 		if(platformFilter) {
-			ws = (jarInfo.platformFilter =~ /.*\(osgi\.ws\=(.*?)\).*/)[ 0 ][ 1 ]
-			os = (jarInfo.platformFilter =~ /.*\(osgi\.os\=(.*?)\).*/)[ 0 ][ 1 ]
-			arch = (jarInfo.platformFilter =~ /.*\(osgi\.arch\=(.*?)\).*/)[ 0 ][ 1 ]
+			ws = (platformFilter =~ /.*\(osgi\.ws\=(.*?)\).*/)[ 0 ][ 1 ]
+			os = (platformFilter =~ /.*\(osgi\.os\=(.*?)\).*/)[ 0 ][ 1 ]
+			arch = (platformFilter =~ /.*\(osgi\.arch\=(.*?)\).*/)[ 0 ][ 1 ]
 		}
 		
 		this.targetFileName = symbolicName + '_' + modifiedVersion + '.jar'

--- a/src/main/groovy/org/standardout/gradle/plugin/platform/internal/ResolvedBundleArtifact.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/platform/internal/ResolvedBundleArtifact.groovy
@@ -274,9 +274,9 @@ class ResolvedBundleArtifact implements BundleArtifact, DependencyArtifact {
 		
 		// Extract target platform constraints if present
 		if(platformFilter) {
-			ws = (jarInfo.platformFilter =~ /.*\(osgi\.ws\=(.*?)\).*/)[ 0 ][ 1 ]
-			os = (jarInfo.platformFilter =~ /.*\(osgi\.os\=(.*?)\).*/)[ 0 ][ 1 ]
-			arch = (jarInfo.platformFilter =~ /.*\(osgi\.arch\=(.*?)\).*/)[ 0 ][ 1 ]
+			ws = (platformFilter =~ /.*\(osgi\.ws\=(.*?)\).*/)[ 0 ][ 1 ]
+			os = (platformFilter =~ /.*\(osgi\.os\=(.*?)\).*/)[ 0 ][ 1 ]
+			arch = (platformFilter =~ /.*\(osgi\.arch\=(.*?)\).*/)[ 0 ][ 1 ]
 		}
 		
 		this.modifiedVersion = modifiedVersion


### PR DESCRIPTION
if i define in the bnd section an instruction ith a platform filter like
instruction 'Eclipse-PlatformFilter', "(& (osgi.ws=win32) (osgi.os=win32) (osgi.arch=x86_64))"
then the build fails. 

The reason is that in both files parsing the platform filter by regular expression it is first checked if a platform filter has been defined but for the regular expression there is not this variable used which has been checked but the value from the jarInfo which may be null.